### PR TITLE
Make get_blocks_metadata() public for selector access

### DIFF
--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -468,7 +468,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 *
 	 * @return array Block metadata.
 	 */
-	protected static function get_blocks_metadata() {
+	public static function get_blocks_metadata() {
 		if ( null !== static::$blocks_metadata ) {
 			return static::$blocks_metadata;
 		}


### PR DESCRIPTION
@ingeniumed As we've discussed separately, `WP_Theme_JSON`'s `get_blocks_metadata` holds the full set registered blocks and their associated selectors. Rather than trying to recreate this data ourselves, we can request to make this method public. We can then use the set of blocks and selectors to transform settings to origin-keyed (i.e. insert `theme` where required), and generate the necessary CSS for nested blocks.