### PR TITLE
Add useSetting tests

### DIFF
--- a/packages/block-editor/src/components/use-setting/test/index.js
+++ b/packages/block-editor/src/components/use-setting/test/index.js
@@ -17,7 +17,7 @@ let selectMock = {};
 const setupSelectMock = () => {
 	selectMock = {
 		getSettings: () => ( {} ),
-		// getBlockParents: () => [],
+		getBlockParents: () => [],
 		getBlockName: () => '',
 	};
 };
@@ -62,7 +62,7 @@ describe( 'useSetting', () => {
 		expect( useSetting( 'layout.contentSize' ) ).toBe( '840px' );
 	} );
 
-	it( 'uses hook override', () => {
+	it( 'uses blockEditor.useSetting.before hook override', () => {
 		mockSettings( {
 			blocks: {
 				'core/test-block': {

--- a/packages/block-editor/src/components/use-setting/test/index.js
+++ b/packages/block-editor/src/components/use-setting/test/index.js
@@ -17,7 +17,7 @@ let selectMock = {};
 const setupSelectMock = () => {
 	selectMock = {
 		getSettings: () => ( {} ),
-		getBlockParents: () => [],
+		// getBlockParents: () => [],
 		getBlockName: () => '',
 	};
 };
@@ -30,21 +30,9 @@ const mockSettings = ( settings ) => {
 	} );
 };
 
-const mockBlockName = ( blockClientId, blockName ) => {
-	selectMock.getBlockName = ( clientId ) => {
-		if ( clientId === blockClientId ) {
-			return blockName;
-		}
-	};
-};
-
 const mockCurrentBlockContext = (
 	blockContext = { name: '', isSelected: false }
 ) => {
-	if ( blockContext.name !== '' && blockContext.clientID !== undefined ) {
-		mockBlockName( blockContext.clientID, blockContext.name );
-	}
-
 	jest.spyOn( BlockEditContext, 'useBlockEditContext' ).mockReturnValue(
 		blockContext
 	);
@@ -53,7 +41,7 @@ const mockCurrentBlockContext = (
 describe( 'useSetting', () => {
 	beforeEach( () => {
 		setupSelectMock();
-		mockCurrentBlockContext( {} );
+		mockCurrentBlockContext();
 	} );
 
 	it( 'uses block setting', () => {

--- a/packages/block-editor/src/components/use-setting/test/index.js
+++ b/packages/block-editor/src/components/use-setting/test/index.js
@@ -1,0 +1,111 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter, removeFilter } from '@wordpress/hooks';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useSetting from '..';
+import * as BlockEditContext from '../../block-edit/context';
+
+// Mock useSelect() functions used by useSetting()
+jest.mock( '@wordpress/data/src/components/use-select' );
+
+let selectMock = {};
+const setupSelectMock = () => {
+	selectMock = {
+		getSettings: () => ( {} ),
+		getBlockParents: () => [],
+		getBlockName: () => '',
+	};
+};
+
+useSelect.mockImplementation( ( callback ) => callback( () => selectMock ) );
+
+const mockSettings = ( settings ) => {
+	selectMock.getSettings = () => ( {
+		__experimentalFeatures: settings,
+	} );
+};
+
+const mockBlockName = ( blockClientId, blockName ) => {
+	selectMock.getBlockName = ( clientId ) => {
+		if ( clientId === blockClientId ) {
+			return blockName;
+		}
+	};
+};
+
+const mockCurrentBlockContext = (
+	blockContext = { name: '', isSelected: false }
+) => {
+	if ( blockContext.name !== '' && blockContext.clientID !== undefined ) {
+		mockBlockName( blockContext.clientID, blockContext.name );
+	}
+
+	jest.spyOn( BlockEditContext, 'useBlockEditContext' ).mockReturnValue(
+		blockContext
+	);
+};
+
+describe( 'useSetting', () => {
+	beforeEach( () => {
+		setupSelectMock();
+		mockCurrentBlockContext( {} );
+	} );
+
+	it( 'uses block setting', () => {
+		mockSettings( {
+			blocks: {
+				'core/test-block': {
+					layout: {
+						contentSize: '840px',
+					},
+				},
+			},
+		} );
+
+		mockCurrentBlockContext( {
+			name: 'core/test-block',
+		} );
+
+		expect( useSetting( 'layout.contentSize' ) ).toBe( '840px' );
+	} );
+
+	it( 'uses hook override', () => {
+		mockSettings( {
+			blocks: {
+				'core/test-block': {
+					layout: {
+						contentSize: '840px',
+					},
+				},
+			},
+		} );
+
+		mockCurrentBlockContext( {
+			name: 'core/test-block',
+		} );
+
+		addFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before',
+			( result, blockName ) => {
+				if ( blockName === 'core/test-block' ) {
+					return '960px';
+				}
+
+				return result;
+			}
+		);
+
+		expect( useSetting( 'layout.contentSize' ) ).toBe( '960px' );
+
+		removeFilter(
+			'blockEditor.useSetting.before',
+			'test/useSetting.before'
+		);
+	} );
+} );


### PR DESCRIPTION
Adds two tests:

1. Getting the value of `layout.contentSize` from settings normally
2. Getting the value of `layout.contentSize` from `blockEditor.useSetting.before` hook override

There's unfortunately still a lot of mocking work being done. `useSelect()` internally calls:

- `select( blockEditorStore ).getSettings`
- `select( blockEditorStore ).getBlockParents`
- `select( blockEditorStore ).getBlockName`

which all break when called outside of a React component. As far as I'm aware, these need to be mocked in order to unit test `useSetting`. This makes the tests a bit brittle, but hopefully there's still some value in adding tests.